### PR TITLE
propagate serde, prost feature flags through ring signer deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2959,6 +2959,7 @@ dependencies = [
  "hkdf",
  "lazy_static",
  "mc-core-types",
+ "mc-crypto-dalek",
  "mc-crypto-hashes",
  "mc-crypto-keys",
  "mc-test-vectors-definitions",
@@ -3024,6 +3025,26 @@ version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
+ "mc-crypto-dalek-backend-simd",
+ "mc-crypto-dalek-backend-u64",
+ "x25519-dalek",
+]
+
+[[package]]
+name = "mc-crypto-dalek-backend-simd"
+version = "2.0.0"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519-dalek",
+ "x25519-dalek",
+]
+
+[[package]]
+name = "mc-crypto-dalek-backend-u64"
+version = "2.0.0"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519-dalek",
  "x25519-dalek",
 ]
 
@@ -3035,6 +3056,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
  "generic-array",
+ "mc-crypto-dalek",
  "mc-crypto-digestible-derive",
  "merlin",
  "x25519-dalek",
@@ -3183,9 +3205,11 @@ version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
+ "ed25519-dalek",
  "hex_fmt",
  "mc-account-keys",
  "mc-account-keys-types",
+ "mc-core-types",
  "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-digestible-test-utils",

--- a/account-keys/Cargo.toml
+++ b/account-keys/Cargo.toml
@@ -5,11 +5,18 @@ authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"
 
+[features]
+std = []
+prost = [ "dep:prost", "mc-crypto-keys/prost", "mc-util-repr-bytes/prost" ]
+serde = [ "mc-crypto-keys/serde" ]
+default = [ "std", "prost", "serde", "mc-util-serial", "mc-crypto-digestible/default", "mc-crypto-hashes/default" ]
+
+
 [dependencies]
 # External dependencies
 displaydoc = { version = "0.2", default-features = false }
 hkdf = "0.12.3"
-prost = { version = "0.11", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.11", optional = true, default-features = false, features = ["prost-derive"] }
 rand_core = { version = "0.6", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
@@ -19,17 +26,13 @@ mc-account-keys-types = { path = "types" }
 mc-core = { path = "../core", default_features = false }
 mc-crypto-digestible = { path = "../crypto/digestible" }
 mc-crypto-hashes = { path = "../crypto/hashes" }
-mc-crypto-keys = { path = "../crypto/keys", default-features = false, features = ["prost"] }
+mc-crypto-keys = { path = "../crypto/keys", default-features = false }
 mc-fog-sig-authority = { path = "../fog/sig/authority" }
 mc-util-from-random = { path = "../util/from-random" }
-mc-util-repr-bytes = { path = "../util/repr-bytes", default-features = false, features = ["alloc", "prost"] }
-mc-util-serial = { path = "../util/serial" }
+mc-util-repr-bytes = { path = "../util/repr-bytes", default-features = false, features = ["alloc"] }
+mc-util-serial = { path = "../util/serial", optional = true }
 
-[target.'cfg(any(target_feature = "avx2", target_feature = "avx"))'.dependencies]
-curve25519-dalek = { version = "4.0.0-pre.2", default-features = false, features = ["simd_backend", "nightly"] }
-
-[target.'cfg(not(any(target_feature = "avx2", target_feature = "avx")))'.dependencies]
-curve25519-dalek = { version = "4.0.0-pre.2", default-features = false, features = ["nightly", "u64_backend"] }
+curve25519-dalek = { version = "4.0.0-pre.2", default-features = false, features = ["nightly"] }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/account-keys/src/account_keys.rs
+++ b/account-keys/src/account_keys.rs
@@ -34,6 +34,7 @@ use mc_crypto_digestible::Digestible;
 use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 use mc_fog_sig_authority::{Signer as AuthoritySigner, Verifier as AuthorityVerifier};
 use mc_util_from_random::FromRandom;
+#[cfg(feature = "prost")]
 use prost::Message;
 use rand_core::{CryptoRng, RngCore};
 use zeroize::Zeroize;
@@ -43,20 +44,21 @@ pub use mc_core::consts::{
     INVALID_SUBADDRESS_INDEX,
 };
 /// A MobileCoin user's public subaddress.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Message, Clone, Digestible)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Digestible)]
+#[cfg_attr(feature = "prost", derive(Message))]
 pub struct PublicAddress {
     /// The user's public subaddress view key 'C'.
-    #[prost(message, required, tag = "1")]
+    #[cfg_attr(feature = "prost", prost(message, required, tag = "1"))]
     view_public_key: RistrettoPublic,
 
     /// The user's public subaddress spend key `D`.
-    #[prost(message, required, tag = "2")]
+    #[cfg_attr(feature = "prost", prost(message, required, tag = "2"))]
     spend_public_key: RistrettoPublic,
 
     /// This is the URL to talk to the fog report server.
     /// Empty if no fog for this public address, should be parseable as
     /// mc_util_uri::FogUri.
-    #[prost(string, tag = "3")]
+    #[cfg_attr(feature = "prost", prost(string, tag = "3"))]
     #[digestible(never_omit)]
     fog_report_url: String,
 
@@ -64,7 +66,7 @@ pub struct PublicAddress {
     /// This id string indicates which of the reports to use.
     ///
     /// Empty if no fog for this public address.
-    #[prost(string, tag = "4")]
+    #[cfg_attr(feature = "prost", prost(string, tag = "4"))]
     #[digestible(never_omit)]
     fog_report_id: String,
 
@@ -73,7 +75,7 @@ pub struct PublicAddress {
     ///
     /// Empty if no fog for this public address, must be parseable as a
     /// [`SchnorrkelSignature`].
-    #[prost(bytes, tag = "5")]
+    #[cfg_attr(feature = "prost", prost(bytes, tag = "5"))]
     #[digestible(never_omit)]
     fog_authority_sig: Vec<u8>,
 }
@@ -224,29 +226,31 @@ impl FromRandom for PublicAddress {
 /// Complete AccountKey, containing the pair of secret keys, which can be used
 /// for spending, and optionally some fog-related info,
 /// can be used for spending. This should only ever be present in client code.
-#[derive(Clone, Message, Zeroize)]
+#[derive(Clone, Zeroize)]
+#[cfg_attr(feature = "prost", derive(Message))]
+#[cfg_attr(not(feature = "prost"), derive(Debug))]
 #[zeroize(drop)]
 pub struct AccountKey {
     /// Private key 'a' used for view-key matching.
-    #[prost(message, required, tag = "1")]
+    #[cfg_attr(feature = "prost", prost(message, required, tag = "1"))]
     view_private_key: RistrettoPrivate,
 
     /// Private key `b` used for spending.
-    #[prost(message, required, tag = "2")]
+    #[cfg_attr(feature = "prost", prost(message, required, tag = "2"))]
     spend_private_key: RistrettoPrivate,
 
     /// Fog Report server url (if user has Fog service), empty string otherwise
-    #[prost(string, tag = "3")]
+    #[cfg_attr(feature = "prost", prost(string, tag = "3"))]
     fog_report_url: String,
 
     /// Fog Report Key (if user has Fog service), empty otherwise
     /// The key labelling the report to use, from among the several reports
     /// which might be served by the fog report server.
-    #[prost(string, tag = "4")]
+    #[cfg_attr(feature = "prost", prost(string, tag = "4"))]
     fog_report_id: String,
 
     /// Fog Authority Key Fingerprint (if user has Fog service), empty otherwise
-    #[prost(bytes, tag = "5")]
+    #[cfg_attr(feature = "prost", prost(bytes, tag = "5"))]
     fog_authority_spki: Vec<u8>,
 }
 
@@ -520,15 +524,16 @@ impl AccountKey {
 }
 
 /// View AccountKey, containing the view private key and the spend public key.
-#[derive(Clone, Message, Zeroize)]
+#[derive(Clone, Zeroize)]
+#[cfg_attr(feature = "prost", derive(Message))]
 #[zeroize(drop)]
 pub struct ViewAccountKey {
     /// Private key 'a' used for view-key matching.
-    #[prost(message, required, tag = "1")]
+    #[cfg_attr(feature = "prost", prost(message, required, tag = "1"))]
     view_private_key: RistrettoPrivate,
 
     /// Public key `B` used for generating Public Addresses.
-    #[prost(message, required, tag = "2")]
+    #[cfg_attr(feature = "prost", prost(message, required, tag = "2"))]
     spend_public_key: RistrettoPublic,
 }
 

--- a/account-keys/src/identity.rs
+++ b/account-keys/src/identity.rs
@@ -20,11 +20,16 @@ use hkdf::SimpleHkdf;
 use mc_crypto_hashes::Blake2b256;
 use mc_crypto_keys::RistrettoPrivate;
 use mc_util_from_random::FromRandom;
+#[cfg(feature = "prost")]
+use mc_util_repr_bytes::derive_prost_message_from_repr_bytes;
 use mc_util_repr_bytes::{
-    derive_debug_and_display_hex_from_as_ref, derive_prost_message_from_repr_bytes,
-    derive_repr_bytes_from_as_ref_and_try_from, typenum::U32, LengthMismatch,
+    derive_debug_and_display_hex_from_as_ref, derive_repr_bytes_from_as_ref_and_try_from,
+    typenum::U32, LengthMismatch,
 };
+
+#[cfg(feature = "prost")]
 use prost::Message;
+
 use rand_core::{CryptoRng, RngCore};
 use zeroize::Zeroize;
 
@@ -75,24 +80,27 @@ impl FromRandom for RootEntropy {
 }
 
 derive_repr_bytes_from_as_ref_and_try_from!(RootEntropy, U32);
-derive_prost_message_from_repr_bytes!(RootEntropy);
 derive_debug_and_display_hex_from_as_ref!(RootEntropy);
+
+#[cfg(feature = "prost")]
+derive_prost_message_from_repr_bytes!(RootEntropy);
 
 /// A RootIdentity contains 32 bytes of root entropy (for deriving private keys
 /// using a KDF), together with any fog data for the account.
-#[derive(Clone, PartialEq, Eq, Hash, Message)]
+#[derive(Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "prost", derive(Message))]
 pub struct RootIdentity {
     /// Root entropy used to derive a user's private keys.
-    #[prost(message, required, tag = 1)]
+    #[cfg_attr(feature = "prost", prost(message, required, tag = 1))]
     pub root_entropy: RootEntropy,
     /// Fog report url
-    #[prost(string, tag = 2)]
+    #[cfg_attr(feature = "prost", prost(string, tag = 2))]
     pub fog_report_url: String,
     /// Fog report id
-    #[prost(string, tag = 3)]
+    #[cfg_attr(feature = "prost", prost(string, tag = 3))]
     pub fog_report_id: String,
     /// Fog authority subjectPublicKeyInfo
-    #[prost(bytes, tag = 4)]
+    #[cfg_attr(feature = "prost", prost(bytes, tag = 4))]
     pub fog_authority_spki: Vec<u8>,
 }
 

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -983,6 +983,7 @@ dependencies = [
  "glob",
  "hkdf",
  "mc-core-types",
+ "mc-crypto-dalek",
  "mc-crypto-hashes",
  "mc-crypto-keys",
  "sha2",
@@ -1038,7 +1039,23 @@ version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
+ "mc-crypto-dalek-backend-simd",
+ "mc-crypto-dalek-backend-u64",
  "x25519-dalek",
+]
+
+[[package]]
+name = "mc-crypto-dalek-backend-simd"
+version = "2.0.0"
+dependencies = [
+ "curve25519-dalek",
+]
+
+[[package]]
+name = "mc-crypto-dalek-backend-u64"
+version = "2.0.0"
+dependencies = [
+ "curve25519-dalek",
 ]
 
 [[package]]
@@ -1049,6 +1066,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
  "generic-array",
+ "mc-crypto-dalek",
  "mc-crypto-digestible-derive",
  "merlin",
  "x25519-dalek",
@@ -1168,9 +1186,9 @@ version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
- "hex_fmt",
- "mc-account-keys",
+ "ed25519-dalek",
  "mc-account-keys-types",
+ "mc-core-types",
  "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-hashes",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,7 +11,7 @@ bip39 = ["dep:tiny-bip39", "dep:slip10_ed25519"]
 internals = [ ]
 serde = ["dep:serde", "mc-core-types/serde"]
 
-default = ["bip39"]
+default = [ "bip39", "mc-crypto-dalek/default" ]
 
 [dependencies]
 curve25519-dalek = { version = "4.0.0-pre.2", default-features = false }
@@ -24,6 +24,7 @@ tiny-bip39 = { version = "1.0", optional = true }
 zeroize = { version = "1.5", default-features = false }
 
 mc-core-types = { path = "./types" }
+mc-crypto-dalek = { path = "../crypto/dalek", default-features = false }
 mc-crypto-hashes = { path = "../crypto/hashes", default-features = false }
 mc-crypto-keys = { path = "../crypto/keys", default-features = false }
 

--- a/crypto/dalek/Cargo.toml
+++ b/crypto/dalek/Cargo.toml
@@ -7,22 +7,23 @@ edition = "2021"
 
 [features]
 serde = [ "curve25519-dalek/serde", "ed25519-dalek/serde" ]
+alloc = [ "curve25519-dalek/alloc", "ed25519-dalek/alloc" ]
 
+# `default` feature enables curve25519-dalek target detection for x86_64 with and without AVX
+default = [ "serde", "alloc", "mc-crypto-dalek-backend-u64/default", "mc-crypto-dalek-backend-simd/default" ]
 
-# Use simd backend for x86_64 platforms with `avx` or `avx2` support
-[target.'cfg(all(any(target_feature = "avx2", target_feature = "avx"), target_arch = "x86_64"))'.dependencies]
-curve25519-dalek = { version = "4.0.0-pre.2", default-features = false, features = ["simd_backend", "nightly"] }
-ed25519-dalek = { version = "2.0.0-pre.1", default-features = false, features = ["nightly", "simd_backend"] }
-x25519-dalek = { version = "2.0.0-pre.2", default-features = false, features = ["nightly"] }
-
-# Use u64 backend for x86_64 platforms without avx or avx2
-[target.'cfg(all(not(any(target_feature = "avx2", target_feature = "avx")), target_arch = "x86_64"))'.dependencies]
-curve25519-dalek = { version = "4.0.0-pre.2", default-features = false, features = ["nightly", "u64_backend"] }
-ed25519-dalek = { version = "2.0.0-pre.1", default-features = false, features = ["nightly", "u64_backend"] }
-x25519-dalek = { version = "2.0.0-pre.2", default-features = false, features = ["nightly"] }
-
-# Otherwise let the platform folks make their own choices
-[target.'cfg(not(target_arch = "x86_64"))'.dependencies]
+[dependencies]
 curve25519-dalek = { version = "4.0.0-pre.2", default-features = false, features = ["nightly"] }
 ed25519-dalek = { version = "2.0.0-pre.1", default-features = false, features = ["nightly"]  }
 x25519-dalek = { version = "2.0.0-pre.2", default-features = false, features = ["nightly"] }
+
+# We can't have per-target-features, but we can have per-target dependencies with feature gates...
+# This is a wild hack so we can magically pick up backends while allowing them to be disabled when required.
+# if `mc-crypto-dalek/default` is selected we'll pull in the avx or u64 backends based on the target,
+# otherwise backend selection is up to the user
+
+[target.'cfg(all(any(target_feature = "avx2", target_feature = "avx"), target_arch = "x86_64"))'.dependencies]
+mc-crypto-dalek-backend-simd = { path = "./simd", default_features = false }
+
+[target.'cfg(all(not(any(target_feature = "avx2", target_feature = "avx")), target_arch = "x86_64"))'.dependencies]
+mc-crypto-dalek-backend-u64 = { path = "./u64", default_features = false }

--- a/crypto/dalek/simd/Cargo.toml
+++ b/crypto/dalek/simd/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "mc-crypto-dalek-backend-simd"
+description = "MobileCoin Dalek Crypto Backend Helper (SIMD)"
+version = "2.0.0"
+authors = ["MobileCoin"]
+edition = "2021"
+
+
+[features]
+default = [ "curve25519-dalek" ]
+
+[dependencies]
+curve25519-dalek = { version = "4.0.0-pre.2", optional=true, default-features = false, features = ["nightly", "simd_backend"] }
+ed25519-dalek = { version = "2.0.0-pre.1", optional=true, default-features = false, features = ["nightly", "simd_backend"]  }
+x25519-dalek = { version = "2.0.0-pre.2", optional=true, default-features = false, features = ["nightly", "u64_backend"] }

--- a/crypto/dalek/simd/src/lib.rs
+++ b/crypto/dalek/simd/src/lib.rs
@@ -1,0 +1,1 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation

--- a/crypto/dalek/src/lib.rs
+++ b/crypto/dalek/src/lib.rs
@@ -5,11 +5,11 @@
 
 #![no_std]
 
-/// Re-export of ed25519_dalek
-pub use ed25519_dalek::{self as ed25519};
-
 /// Re-export of curve25519_dalek
 pub use curve25519_dalek::{self as curve25519};
+
+/// Re-export of ed25519_dalek
+pub use ed25519_dalek::{self as ed25519};
 
 /// Re-export of x25519_dalek
 pub use x25519_dalek::{self as x25519};

--- a/crypto/dalek/u64/Cargo.toml
+++ b/crypto/dalek/u64/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "mc-crypto-dalek-backend-u64"
+description = "MobileCoin Dalek Crypto Backend Helper (u64)"
+version = "2.0.0"
+authors = ["MobileCoin"]
+edition = "2021"
+
+
+[features]
+default = [ "curve25519-dalek" ]
+
+[dependencies]
+curve25519-dalek = { version = "4.0.0-pre.2", optional=true, default-features = false, features = ["nightly", "u64_backend"] }
+ed25519-dalek = { version = "2.0.0-pre.1", optional=true, default-features = false, features = ["nightly", "u64_backend"]  }
+x25519-dalek = { version = "2.0.0-pre.2", optional=true, default-features = false, features = ["nightly", "u64_backend"] }

--- a/crypto/dalek/u64/src/lib.rs
+++ b/crypto/dalek/u64/src/lib.rs
@@ -1,0 +1,1 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation

--- a/crypto/digestible/Cargo.toml
+++ b/crypto/digestible/Cargo.toml
@@ -4,26 +4,28 @@ version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 
+
+
 [dependencies]
 cfg-if = "1.0"
 generic-array = "0.14"
 merlin = { version = "3.0", default-features = false }
 
 # For derive support
+mc-crypto-dalek = { path = "../dalek", optional = true, default-features = false }
 mc-crypto-digestible-derive = { path = "./derive", optional = true }
 
 # Built-in support for dalek primitives
 # ed25519-dalek doesn't build without rand feature
+curve25519-dalek = { version = "4.0.0-pre.2", default-features = false, features = ["nightly"], optional = true }
 ed25519-dalek = { version = "2.0.0-pre.1", default-features = false, features = ["rand"], optional = true }
 x25519-dalek = { version = "2.0.0-pre.2", default-features = false, optional = true }
 
-curve25519-dalek = { version = "4.0.0-pre.2", default-features = false, features = ["nightly"], optional = true }
-
 [features]
-default = ["alloc", "derive", "dalek"]
+default = ["alloc", "derive", "dalek", "mc-crypto-dalek/default"]
 # Enables support for types in alloc crate
-alloc = []
+alloc = ["mc-crypto-dalek/alloc"]
 # Enables re-export of derive(Digestible) macro
 derive = ["mc-crypto-digestible-derive"]
 # Enables support for some crypto primitives in dalek crates
-dalek = ["curve25519-dalek", "ed25519-dalek", "x25519-dalek"]
+dalek = [ "mc-crypto-dalek", "curve25519-dalek", "ed25519-dalek", "x25519-dalek"]

--- a/crypto/ring-signature/Cargo.toml
+++ b/crypto/ring-signature/Cargo.toml
@@ -6,20 +6,25 @@ edition = "2021"
 readme = "README.md"
 
 [features]
-alloc = ["serde/alloc", "mc-crypto-digestible/alloc"]
-default = ["alloc"]
+alloc = [ "serde/alloc", "mc-crypto-digestible/alloc", "mc-util-repr-bytes/alloc", "mc-transaction-types/alloc", "mc-crypto-dalek/alloc" ]
+serde = [ "dep:serde", "mc-crypto-dalek/serde", "mc-crypto-keys/serde" ]
+prost = [ "dep:prost", "mc-crypto-keys/prost" ]
+internals = []
+default = [ "alloc", "serde", "prost", "mc-util-repr-bytes/default", "mc-crypto-dalek/default", "mc-crypto-hashes/default" ]
 
 [dependencies]
 
-curve25519-dalek = { version = "4.0.0-pre.2", default-features = false, features = ["nightly", "serde"] }
+curve25519-dalek = { version = "4.0.0-pre.2", default-features = false, features = ["nightly"] }
+ed25519-dalek = { version = "2.0.0-pre.1", default-features = false, features = ["nightly"] }
+
 # External dependencies
 displaydoc = { version = "0.2", default-features = false }
-hex_fmt = "0.3"
-mc-account-keys = { path = "../../account-keys", default-features = false }
+hex_fmt = { version = "0.3", optional = true }
 
 # MobileCoin dependencies
 mc-account-keys-types = { path = "../../account-keys/types", default-features = false }
-mc-crypto-dalek = { path = "../../crypto/dalek" }
+mc-core-types = { path = "../../core/types", default-features = false }
+mc-crypto-dalek = { path = "../../crypto/dalek", default_features = false }
 mc-crypto-digestible = { path = "../../crypto/digestible", default-features = false, features = ["dalek", "derive"] }
 mc-crypto-hashes = { path = "../../crypto/hashes" }
 mc-crypto-keys = { path = "../../crypto/keys", default-features = false }
@@ -27,11 +32,12 @@ mc-transaction-types = { path = "../../transaction/types" }
 mc-util-from-random = { path = "../../util/from-random" }
 mc-util-repr-bytes = { path = "../../util/repr-bytes" }
 mc-util-serial = { path = "../../util/serial" }
+
 # Enable all default features not known to break code coverage builds
 proptest = { version = "1.0", default-features = false, features = ["default-code-coverage"], optional = true }
-prost = { version = "0.11", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.11", optional = true, default-features = false, features = ["prost-derive"] }
 rand_core = { version = "0.6.4", default-features = false }
-serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 subtle = { version = "2.4.1", default-features = false, features = ["i128"] }
 zeroize = { version = "1", default-features = false }
 

--- a/crypto/ring-signature/signer/Cargo.toml
+++ b/crypto/ring-signature/signer/Cargo.toml
@@ -5,6 +5,12 @@ authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"
 
+[features]
+serde = [ "dep:serde", "mc-crypto-ring-signature/serde", "mc-crypto-dalek/serde" ]
+alloc = [ "serde/alloc", "mc-crypto-ring-signature/alloc", "mc-crypto-dalek/alloc" ]
+
+default = [ "serde", "alloc", "mc-crypto-dalek/default" ]
+
 [dependencies]
 # External dependencies
 displaydoc = { version = "0.2", default-features = false }
@@ -12,15 +18,15 @@ generic-array = { version = "0.14", features = ["serde", "more_lengths"] }
 hex_fmt = "0.3"
 prost = { version = "0.11", default-features = false, features = ["prost-derive"] }
 rand_core = { version = "0.6", default-features = false }
-serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 subtle = { version = "2.4.1", default-features = false, features = ["i128"] }
 zeroize = { version = "1", default-features = false }
 
 # MobileCoin dependencies
 mc-account-keys = { path = "../../../account-keys", default-features = false }
-mc-crypto-dalek = { path = "../../dalek" }
+mc-crypto-dalek = { path = "../../dalek", default-features = false }
 mc-crypto-keys = { path = "../../keys", default-features = false }
-mc-crypto-ring-signature = { path = "..", default-features = false }
+mc-crypto-ring-signature = { path = "..", default-features = false, features = [ "alloc", "serde", "prost" ] }
 mc-transaction-types = { path = "../../../transaction/types" }
 mc-util-serial = { path = "../../../util/serial" }
 

--- a/crypto/ring-signature/signer/src/traits.rs
+++ b/crypto/ring-signature/signer/src/traits.rs
@@ -6,11 +6,13 @@ use mc_crypto_keys::{KeyError, RistrettoPrivate};
 use mc_crypto_ring_signature::{Error as RingSignatureError, ReducedTxOut, RingMLSAG, Scalar};
 use mc_transaction_types::Amount;
 use rand_core::CryptoRngCore;
-use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 /// A representation of the part of the input ring needed to create an MLSAG
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SignableInputRing {
     /// A reduced representation of the TxOut's in the ring. For each ring
     /// member we have only:
@@ -27,7 +29,8 @@ pub struct SignableInputRing {
 
 /// The secrets needed to create a signature that spends an existing output as
 /// an input
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, Zeroize)]
+#[derive(Clone, Debug, PartialEq, Eq, Zeroize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[zeroize(drop)]
 pub struct InputSecret {
     /// Represents either the one-time private key, or data to derive it
@@ -49,7 +52,8 @@ pub struct InputSecret {
 /// ourselves.
 ///
 /// This enum selects which path to the one-time private key is taken.
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, Zeroize)]
+#[derive(Clone, Debug, PartialEq, Eq, Zeroize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[zeroize(drop)]
 pub enum OneTimeKeyDeriveData {
     /// The one-time private key for the output
@@ -118,7 +122,8 @@ impl<S: RingSigner> RingSigner for &S {
 }
 
 /// An error that can occur when using an abstract RingSigner
-#[derive(Clone, Debug, Deserialize, Display, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Display, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Error {
     /// True input not owned by this subaddress
     TrueInputNotOwned,

--- a/crypto/ring-signature/src/amount/compressed_commitment.rs
+++ b/crypto/ring-signature/src/amount/compressed_commitment.rs
@@ -8,14 +8,20 @@ use curve25519_dalek::ristretto::CompressedRistretto;
 use mc_crypto_digestible::Digestible;
 use mc_util_repr_bytes::{
     derive_core_cmp_from_as_ref, derive_debug_and_display_hex_from_as_ref,
-    derive_prost_message_from_repr_bytes, derive_try_from_slice_from_repr_bytes, typenum::U32,
-    GenericArray, ReprBytes,
+    derive_try_from_slice_from_repr_bytes, typenum::U32, GenericArray, ReprBytes,
 };
-use serde::{Deserialize, Serialize};
+
 use zeroize::Zeroize;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "prost")]
+use mc_util_repr_bytes::derive_prost_message_from_repr_bytes;
+
 /// A Pedersen commitment in compressed Ristretto format.
-#[derive(Copy, Clone, Default, Deserialize, Digestible, Serialize, Zeroize)]
+#[derive(Copy, Clone, Default, Digestible, Zeroize)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[digestible(transparent)]
 pub struct CompressedCommitment {
     /// A Pedersen commitment `v*H + b*G` to a quantity `v` with blinding `b`,
@@ -72,8 +78,10 @@ impl ReprBytes for CompressedCommitment {
 
 derive_core_cmp_from_as_ref!(CompressedCommitment, [u8; 32]);
 derive_debug_and_display_hex_from_as_ref!(CompressedCommitment);
-derive_prost_message_from_repr_bytes!(CompressedCommitment);
 derive_try_from_slice_from_repr_bytes!(CompressedCommitment);
+
+#[cfg(feature = "prost")]
+derive_prost_message_from_repr_bytes!(CompressedCommitment);
 
 #[cfg(test)]
 #[allow(non_snake_case)]

--- a/crypto/ring-signature/src/lib.rs
+++ b/crypto/ring-signature/src/lib.rs
@@ -5,7 +5,9 @@
 
 #![no_std]
 #![deny(missing_docs)]
+#![cfg_attr(not(feature = "alloc"), allow(dead_code))]
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 use crate::onetime_keys::create_shared_secret;
@@ -21,8 +23,11 @@ pub mod proptest_fixtures;
 
 pub use amount::{Commitment, CompressedCommitment};
 pub use ring_signature::{
-    generators, CurveScalar, Error, KeyImage, PedersenGens, ReducedTxOut, RingMLSAG, Scalar,
+    generators, CurveScalar, Error, KeyImage, PedersenGens, ReducedTxOut, Scalar,
 };
+
+#[cfg(feature = "alloc")]
+pub use ring_signature::RingMLSAG;
 
 /// Get the shared secret for a transaction output.
 ///

--- a/crypto/ring-signature/src/ring_signature/curve_scalar.rs
+++ b/crypto/ring-signature/src/ring_signature/curve_scalar.rs
@@ -11,15 +11,20 @@ use mc_crypto_digestible::Digestible;
 use mc_util_from_random::FromRandom;
 use mc_util_repr_bytes::{
     derive_core_cmp_from_as_ref, derive_debug_and_display_hex_from_as_ref,
-    derive_prost_message_from_repr_bytes, derive_try_from_slice_from_repr_bytes, typenum::U32,
-    GenericArray, ReprBytes,
+    derive_try_from_slice_from_repr_bytes, typenum::U32, GenericArray, ReprBytes,
 };
 use rand_core::{CryptoRng, RngCore};
-use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
+#[cfg(feature = "prost")]
+use mc_util_repr_bytes::derive_prost_message_from_repr_bytes;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// A curve scalar
-#[derive(Copy, Clone, Default, Serialize, Deserialize, Digestible, Zeroize)]
+#[derive(Copy, Clone, Default, Digestible, Zeroize)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[digestible(transparent)]
 pub struct CurveScalar {
     /// The scalar value
@@ -114,8 +119,9 @@ impl ReprBytes for CurveScalar {
 
 derive_core_cmp_from_as_ref!(CurveScalar, [u8; 32]);
 derive_debug_and_display_hex_from_as_ref!(CurveScalar);
-derive_prost_message_from_repr_bytes!(CurveScalar);
 derive_try_from_slice_from_repr_bytes!(CurveScalar);
+#[cfg(feature = "prost")]
+derive_prost_message_from_repr_bytes!(CurveScalar);
 
 #[cfg(test)]
 mod tests {
@@ -146,6 +152,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "prost")]
     /// CurveScalar should serialize and deserialize.
     fn test_curve_scalar_roundtrip() {
         let five = CurveScalar::from(5u64);

--- a/crypto/ring-signature/src/ring_signature/error.rs
+++ b/crypto/ring-signature/src/ring_signature/error.rs
@@ -3,10 +3,13 @@
 //! Errors which can occur in connection to RingMLSAG signatures
 
 use displaydoc::Display;
+
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// An error which can occur when signing or verifying an MLSAG
-#[derive(Clone, Debug, Deserialize, Display, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Display, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Error {
     /// Incorrect length for array copy, provided `{0}`, required `{1}`.
     LengthMismatch(usize, usize),
@@ -28,6 +31,12 @@ pub enum Error {
 
     /// Value not conserved
     ValueNotConserved,
+
+    /// Unexpected tx_out index
+    UnexpectedTxout,
+
+    /// Invalid signing state
+    InvalidState,
 }
 
 impl From<mc_util_repr_bytes::LengthMismatch> for Error {

--- a/crypto/ring-signature/src/ring_signature/key_image.rs
+++ b/crypto/ring-signature/src/ring_signature/key_image.rs
@@ -6,12 +6,17 @@ use mc_crypto_digestible::Digestible;
 use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 use mc_util_repr_bytes::{
     derive_core_cmp_from_as_ref, derive_debug_and_display_hex_from_as_ref,
-    derive_prost_message_from_repr_bytes, derive_repr_bytes_from_as_ref_and_try_from, typenum::U32,
-    LengthMismatch,
+    derive_repr_bytes_from_as_ref_and_try_from, typenum::U32, LengthMismatch,
 };
+
+#[cfg(feature = "prost")]
+use mc_util_repr_bytes::derive_prost_message_from_repr_bytes;
+
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, Default, Serialize, Deserialize, Digestible)]
+#[derive(Copy, Clone, Default, Digestible)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[digestible(transparent)]
 /// The "image" of a private key `x`: I = x * Hp(x * G) = x * Hp(P).
 pub struct KeyImage {
@@ -26,6 +31,7 @@ impl KeyImage {
     }
 
     /// Copies `self` into a new Vec.
+    #[cfg(feature = "alloc")]
     pub fn to_vec(&self) -> alloc::vec::Vec<u8> {
         self.point.as_bytes().to_vec()
     }
@@ -92,6 +98,8 @@ impl TryFrom<&[u8]> for KeyImage {
 }
 
 derive_repr_bytes_from_as_ref_and_try_from!(KeyImage, U32);
-derive_prost_message_from_repr_bytes!(KeyImage);
 derive_core_cmp_from_as_ref!(KeyImage, [u8; 32]);
 derive_debug_and_display_hex_from_as_ref!(KeyImage);
+
+#[cfg(feature = "prost")]
+derive_prost_message_from_repr_bytes!(KeyImage);

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -910,6 +910,7 @@ dependencies = [
  "glob",
  "hkdf",
  "mc-core-types",
+ "mc-crypto-dalek",
  "mc-crypto-hashes",
  "mc-crypto-keys",
  "sha2",
@@ -965,7 +966,23 @@ version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
+ "mc-crypto-dalek-backend-simd",
+ "mc-crypto-dalek-backend-u64",
  "x25519-dalek",
+]
+
+[[package]]
+name = "mc-crypto-dalek-backend-simd"
+version = "2.0.0"
+dependencies = [
+ "curve25519-dalek",
+]
+
+[[package]]
+name = "mc-crypto-dalek-backend-u64"
+version = "2.0.0"
+dependencies = [
+ "curve25519-dalek",
 ]
 
 [[package]]
@@ -976,6 +993,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
  "generic-array",
+ "mc-crypto-dalek",
  "mc-crypto-digestible-derive",
  "merlin",
  "x25519-dalek",
@@ -1082,9 +1100,9 @@ version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
- "hex_fmt",
- "mc-account-keys",
+ "ed25519-dalek",
  "mc-account-keys-types",
+ "mc-core-types",
  "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-hashes",

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -879,6 +879,7 @@ dependencies = [
  "glob",
  "hkdf",
  "mc-core-types",
+ "mc-crypto-dalek",
  "mc-crypto-hashes",
  "mc-crypto-keys",
  "sha2",
@@ -934,7 +935,23 @@ version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
+ "mc-crypto-dalek-backend-simd",
+ "mc-crypto-dalek-backend-u64",
  "x25519-dalek",
+]
+
+[[package]]
+name = "mc-crypto-dalek-backend-simd"
+version = "2.0.0"
+dependencies = [
+ "curve25519-dalek",
+]
+
+[[package]]
+name = "mc-crypto-dalek-backend-u64"
+version = "2.0.0"
+dependencies = [
+ "curve25519-dalek",
 ]
 
 [[package]]
@@ -945,6 +962,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
  "generic-array",
+ "mc-crypto-dalek",
  "mc-crypto-digestible-derive",
  "merlin",
  "x25519-dalek",
@@ -1051,9 +1069,9 @@ version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
- "hex_fmt",
- "mc-account-keys",
+ "ed25519-dalek",
  "mc-account-keys-types",
+ "mc-core-types",
  "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-hashes",

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -920,6 +920,7 @@ dependencies = [
  "glob",
  "hkdf",
  "mc-core-types",
+ "mc-crypto-dalek",
  "mc-crypto-hashes",
  "mc-crypto-keys",
  "sha2",
@@ -975,7 +976,23 @@ version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
+ "mc-crypto-dalek-backend-simd",
+ "mc-crypto-dalek-backend-u64",
  "x25519-dalek",
+]
+
+[[package]]
+name = "mc-crypto-dalek-backend-simd"
+version = "2.0.0"
+dependencies = [
+ "curve25519-dalek",
+]
+
+[[package]]
+name = "mc-crypto-dalek-backend-u64"
+version = "2.0.0"
+dependencies = [
+ "curve25519-dalek",
 ]
 
 [[package]]
@@ -986,6 +1003,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
  "generic-array",
+ "mc-crypto-dalek",
  "mc-crypto-digestible-derive",
  "merlin",
  "x25519-dalek",
@@ -1092,9 +1110,9 @@ version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
- "hex_fmt",
- "mc-account-keys",
+ "ed25519-dalek",
  "mc-account-keys-types",
+ "mc-core-types",
  "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-hashes",

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -30,8 +30,8 @@ mc-crypto-digestible = { path = "../../crypto/digestible", features = ["dalek", 
 mc-crypto-hashes = { path = "../../crypto/hashes" }
 mc-crypto-keys = { path = "../../crypto/keys", default-features = false }
 mc-crypto-multisig = { path = "../../crypto/multisig", default-features = false }
-mc-crypto-ring-signature = { path = "../../crypto/ring-signature", default-features = false }
-mc-crypto-ring-signature-signer = { path = "../../crypto/ring-signature/signer", default-features = false }
+mc-crypto-ring-signature = { path = "../../crypto/ring-signature", default-features = false, features = [ "alloc", "serde", "prost" ]}
+mc-crypto-ring-signature-signer = { path = "../../crypto/ring-signature/signer", default-features = false, features = [ "alloc", "serde" ] }
 mc-transaction-types = { path = "../types" }
 mc-util-from-random = { path = "../../util/from-random" }
 mc-util-repr-bytes = { path = "../../util/repr-bytes" }

--- a/transaction/types/Cargo.toml
+++ b/transaction/types/Cargo.toml
@@ -5,12 +5,17 @@ authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"
 
+[features]
+serde = [ "dep:serde" ]
+alloc = [ "serde/alloc" ]
+default = [ "serde", "alloc" ]
+
 [dependencies]
 # External dependencies
 displaydoc = { version = "0.2", default-features = false }
-serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 subtle = { version = "2.4.1", default-features = false, features = ["i128"] }
 zeroize = { version = "1", default-features = false }
 
 # MobileCoin dependencies
-mc-crypto-digestible = { path = "../../crypto/digestible", features = ["dalek", "derive"] }
+mc-crypto-digestible = { path = "../../crypto/digestible", default-features = false, features = ["dalek", "derive"] }

--- a/transaction/types/src/block_version.rs
+++ b/transaction/types/src/block_version.rs
@@ -16,21 +16,9 @@ use serde::{Deserialize, Serialize};
 /// If you need to manipulate block versions that cannot be understood by your
 /// version of `mc-transaction-core`, then you should use u32 to represent
 /// block version numbers.
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Default,
-    Deserialize,
-    Digestible,
-    Eq,
-    Hash,
-    Ord,
-    PartialOrd,
-    PartialEq,
-    Serialize,
-)]
-#[serde(try_from = "u32")]
+#[derive(Clone, Copy, Debug, Default, Digestible, Eq, Hash, Ord, PartialOrd, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(try_from = "u32"))]
 pub struct BlockVersion(u32);
 
 impl TryFrom<u32> for BlockVersion {
@@ -166,7 +154,8 @@ impl Iterator for BlockVersionIterator {
 
 /// An error that can occur when parsing a block version or interpreting u32 as
 /// a block version
-#[derive(Clone, Display, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Display, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum BlockVersionError {
     /// Unsupported block version: {0} > {1}. Try upgrading your software
     UnsupportedBlockVersion(u32, u32),


### PR DESCRIPTION
propagate `prost` and `serde` features through ring-signer related types.

blocked on #2525, to be re-targeted following merge

cc. @jcape @garbageslam

### Motivation

towards streaming ring signatures / in an effort to isolate the procedural and cryptographic changes.
